### PR TITLE
File.dirname(__FILE__)  => __dir__

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
 $TESTING=true
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(__dir__, '..', 'lib')
 


### PR DESCRIPTION
Ruby 2.0+ has a shorthand for `File.dirname(__FILE__)` :golf:
